### PR TITLE
Fix loading backoffice assets

### DIFF
--- a/lib/moon_web/endpoint.ex
+++ b/lib/moon_web/endpoint.ex
@@ -26,6 +26,14 @@ defmodule MoonWeb.Endpoint do
     gzip: false,
     only: ~w(css fonts images js favicon.ico robots.txt)
 
+  # Provide a static plug to serve backoffice files
+  # You can change the `at` value if you are using backoffice
+  plug Plug.Static,
+    at: "/backoffice",
+    from: :backoffice,
+    gzip: false,
+    only: ~w(css js)
+
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
   if code_reloading? do

--- a/lib/moon_web/endpoint.ex
+++ b/lib/moon_web/endpoint.ex
@@ -27,7 +27,7 @@ defmodule MoonWeb.Endpoint do
     only: ~w(css fonts images js favicon.ico robots.txt)
 
   # Provide a static plug to serve backoffice files
-  # You can change the `at` value if you are using backoffice
+  # You can change the `at` value if you are using the "/backoffice" path
   plug Plug.Static,
     at: "/backoffice",
     from: :backoffice,


### PR DESCRIPTION
`/backoffice/js/app.js` is not being served correctly and is instead returning 404. This is because the file is in the `priv/static` of the library and not the demo. Some of the functionality is broken as a result.

This fixes the reference.